### PR TITLE
Add opaque object field for arbitrary quote properties.

### DIFF
--- a/qdb/models.py
+++ b/qdb/models.py
@@ -13,6 +13,7 @@ class Quote(Document):
     num = SequenceField()
     author = StringField()
     body = StringField()
+    props = DictField()
 
     @property
     def added_at(self):
@@ -24,4 +25,5 @@ class Quote(Document):
             'body': self.body,
             'author': self.author,
             'addedAt': self.added_at,
+            'props': self.props,
         }

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -175,3 +175,5 @@ definitions:
       addedAt:
         type: string
         format: date-time
+      props:
+        type: object


### PR DESCRIPTION
`body` is full-text indexed for quote searching so please add any additional non-quote metadata to the `props` field.